### PR TITLE
Update README with deprecation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# THIS REPO IS DEPRECATED!  It's been merged into the `bson` (https://github.com/mongodb/js-bson) repo.
+
 # MongoDB Extended JSON Library  [![][npm_img]][npm_url] [![][travis_img]][travis_url]
 
 


### PR DESCRIPTION
This project isn't being maintained, so pointing folks to its new home inside the js-bson repo. See #26.